### PR TITLE
Removed `react-addons-linked-state-mixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updated dependencies
+- Removed `react-addons-linked-state-mixin`, as it turns out it wasn't used.
 
 ## [0.0.7] - 2016-6-26
 ### Changed

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "mocha": "~3.0.1",
     "phantomjs-prebuilt": "~2.1.3",
     "react": "~0.14.7",
-    "react-addons-linked-state-mixin": "~0.14.7",
     "react-addons-test-utils": "~0.14.7",
     "react-dom": "~0.14.7",
     "watchify": "^3.7.0"


### PR DESCRIPTION
It turns out it wasn't used.
